### PR TITLE
Move deploy namespace into a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,37 @@ Wrap all application processes by [eye]('https://github.com/kostya/eye') monitor
 
 ## Installation
 
+Add this line to your Gemfile:
 
-    gem 'capistrano-eye', github: 'alexsergeyev/capistrano-eye'
+```ruby
+gem 'capistrano-eye'
+```
 
-Enable it in Capfile
+And then run:
 
-    require 'capistrano/eye'
+```bash
+$ bundle
+```
 
+## Usage
+
+Add this line to your `Capfile` and `deploy:restart` will be setup to automatically run after `:publishing` is complete:
+
+```ruby
+require 'capistrano/eye'
+```
+
+The following tasks are available: `eye:load`, `eye:start`, `eye:stop`, `eye:restart`, `eye:info`
+
+If you want the task to run at a different point in your deployment, require `capistrano/eye/no_hook` instead of `capistrano/eye` and then add your own hook in `config/deploy.rb`.
+
+``` ruby
+# Capfile
+require 'capistrano/eye/no_hook'
+
+# config/deploy.rb
+after :some_other_task, :'eye:restart'
+```
 
 ## Configuration
     set :eye_application # capistrano application name by default

--- a/lib/capistrano/eye.rb
+++ b/lib/capistrano/eye.rb
@@ -1,1 +1,1 @@
-load File.expand_path("../tasks/eye.rake", __FILE__)
+load File.expand_path("../tasks/deploy_eye.cap", __FILE__)

--- a/lib/capistrano/eye/no_hook.rb
+++ b/lib/capistrano/eye/no_hook.rb
@@ -1,0 +1,1 @@
+load File.expand_path("../../tasks/eye.cap", __FILE__)

--- a/lib/capistrano/tasks/deploy_eye.cap
+++ b/lib/capistrano/tasks/deploy_eye.cap
@@ -1,0 +1,10 @@
+load File.expand_path('../eye.cap', __FILE__)
+
+namespace :deploy do
+  desc 'Restart your Eye application'
+  task :restart do
+    invoke 'eye:restart'
+  end
+  after :publishing, :restart
+end
+

--- a/lib/capistrano/tasks/eye.cap
+++ b/lib/capistrano/tasks/eye.cap
@@ -20,4 +20,3 @@ namespace :eye do
   before :restart, :load
 end
 
-after 'deploy:publishing', 'eye:restart'


### PR DESCRIPTION
Eye tasks can be loaded into the application without adding the hook to
execute `deploy:restart` automatically.
