### PR TITLE
Bundler support: run eye commands within a project path

### DIFF
--- a/lib/capistrano/tasks/eye.cap
+++ b/lib/capistrano/tasks/eye.cap
@@ -15,7 +15,9 @@ namespace :eye do
     task cmd do
       on roles(fetch(:eye_roles)) do
         with fetch(:eye_env) do
-          execute :eye, cmd, fetch(:eye_application)
+          within(release_path) do
+            execute :eye, cmd, fetch(:eye_application)
+          end
         end
       end
     end
@@ -26,7 +28,9 @@ namespace :eye do
     on roles(fetch(:eye_roles)) do |server|
       puts server.hostname
       with fetch(:eye_env) do
-        puts capture(:eye, :info, fetch(:eye_application))
+        within(release_path) do
+          puts capture(:eye, :info, fetch(:eye_application))
+        end
       end
     end
   end


### PR DESCRIPTION
Hi Alex,

Thank you for the work on this gem!

I've added support for capistrano-bundler in this PR and would like to merge it to the upstream.

When using with capistrano-bundler, the working directory should contain Gemfile. Otherwise, it would fail looking for Gemfile.

I would like to answer any questions regarding this PR. Looking forward to your review.
