### PR TITLE
add quit task

### DIFF
--- a/lib/capistrano/tasks/eye.cap
+++ b/lib/capistrano/tasks/eye.cap
@@ -35,6 +35,17 @@ namespace :eye do
     end
   end
 
+  task :quit do
+    desc 'Quit eye'
+    on roles(fetch(:eye_roles)) do |server|
+      with fetch(:eye_env) do
+        within(release_path) do
+          execute :eye, :quit
+        end
+      end
+    end
+  end
+
   before :start, :load
   before :restart, :load
 end


### PR DESCRIPTION
when using bundled eye in combination with rbenv-vars, it's necessary to quit eye as part of the restart process in order to load new environment. this adds a quit task to make it possible to quit eye from capistrano.
