### PR TITLE
Configuration of eye work dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,13 @@ after :some_other_task, :'eye:restart'
 ```
 
 ## Configuration
-    set :eye_application # capistrano application name by default
-    set :eye_config,     # ./config/eye_application.eye
+```ruby
+set :eye_roles, :app # the role of the server where the eye should be started
+set :eye_env, -> { { rails_env: fetch(:stage) } } # capistrano environment
+set :eye_application, -> { fetch(:application) } # capistrano application name by default
+set :eye_config, -> { "./config/#{fetch(:application)}.eye" } # ./config/eye_application.eye
+set :eye_work_dir, -> { release_path } # working directory path for eye
+```
 
 ## Contributing
 

--- a/lib/capistrano/tasks/eye.cap
+++ b/lib/capistrano/tasks/eye.cap
@@ -3,7 +3,7 @@ namespace :eye do
   task :load do
     on roles(fetch(:eye_roles)) do
       with fetch(:eye_env) do
-        within(release_path) do
+        within fetch(:eye_work_dir) do
           execute :eye, :load, fetch(:eye_config)
         end
       end
@@ -15,7 +15,7 @@ namespace :eye do
     task cmd do
       on roles(fetch(:eye_roles)) do
         with fetch(:eye_env) do
-          within(release_path) do
+          within fetch(:eye_work_dir) do
             execute :eye, cmd, fetch(:eye_application)
           end
         end
@@ -28,7 +28,7 @@ namespace :eye do
     on roles(fetch(:eye_roles)) do |server|
       puts server.hostname
       with fetch(:eye_env) do
-        within(release_path) do
+        within fetch(:eye_work_dir) do
           puts capture(:eye, :info, fetch(:eye_application))
         end
       end
@@ -56,6 +56,7 @@ namespace :load do
     set :eye_env, -> { { rails_env: fetch(:rails_env) || fetch(:stage) } }
     set :eye_application, -> { fetch(:application) }
     set :eye_config, -> { "./config/#{fetch(:application)}.eye" }
+    set :eye_work_dir, -> { release_path }
 
     # Rbenv, Chruby, and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a << 'eye'


### PR DESCRIPTION
Hi!

I added the ability to configure working directory eye.

Now the eye works in a folder `release_path`. I would like to run in your eye `current_path`. On this added ability to customize the working directory.

By default, leave the old value `release_path`.

Sorry for my English. I used Google Translate.
