### PR TITLE
Fix description for tasks info and quit

### DIFF
--- a/lib/capistrano/tasks/eye.cap
+++ b/lib/capistrano/tasks/eye.cap
@@ -23,8 +23,8 @@ namespace :eye do
     end
   end
 
+  desc 'Show application status'
   task :info do
-    desc 'Show application status'
     on roles(fetch(:eye_roles)) do |server|
       puts server.hostname
       with fetch(:eye_env) do
@@ -35,8 +35,8 @@ namespace :eye do
     end
   end
 
+  desc 'Quit eye'
   task :quit do
-    desc 'Quit eye'
     on roles(fetch(:eye_roles)) do |server|
       with fetch(:eye_env) do
         within(release_path) do


### PR DESCRIPTION
Hello. Today I have ran `bundle exec rake -T` and didn't find tasks `eye:info` and `eye:quit`. I read source code and noticed that `desc` is written after `task`, not before it 😅

Here is my PR to fix it. You can run `bundle exec rake -T` and see

```
rake eye:info         # Show application status
rake eye:quit         # Quit eye
```